### PR TITLE
Patch apiGet() to allow further curl options to be passed

### DIFF
--- a/src/Krizalys/Onedrive/Client.php
+++ b/src/Krizalys/Onedrive/Client.php
@@ -281,13 +281,19 @@ class Client {
 	 * Performs a call to the OneDrive API using the GET method.
 	 *
 	 * @param  (string) $path - The path of the API call (eg. me/skydrive).
+	 * @param  (array) $options - Further curl options to set.
 	 */
-	public function apiGet($path) {
+	public function apiGet($path, $options = array()) {
 		$url = self::API_URL . $path
 			. '?access_token=' . urlencode($this->_state->token->data->access_token);
 
 		$curl = self::_createCurl($path);
+		
 		curl_setopt($curl, CURLOPT_URL, $url);
+
+		foreach ($options as $option => $value) {
+			curl_setopt($curl, $option, $value);
+		}
 		return $this->_processResult($curl);
 	}
 


### PR DESCRIPTION
This patch to the apiGet() client method allows the caller to pass their own Curl options, for maximum flexibility.

(In my case, I wished to set the CURLOPT_RANGE option, as I am dealing with potentially enormous files that may be too big to read into memory in one go, so I am wanting to download in chunks).