### PR TITLE
Client.php - handle curl error in obtainAccessToken()

### DIFF
--- a/src/Krizalys/Onedrive/Client.php
+++ b/src/Krizalys/Onedrive/Client.php
@@ -257,6 +257,15 @@ class Client {
 		));
 
 		$result = curl_exec($curl);
+		
+		if (false === $result) {
+			if (curl_errno($curl)) {
+				throw new \Exception('Curl error: '.curl_error($curl));
+			} else {
+				throw new \Exception('Curl error: empty response');
+			}
+		}
+
 		$decoded = json_decode($result);
 
 		if (null === $decoded) {


### PR DESCRIPTION
The current exception handling doesn't return curl errors. This fixes it.