### PR TITLE
Added `path` variable to get method

### DIFF
--- a/src/Proxy/ItemReferenceProxy.php
+++ b/src/Proxy/ItemReferenceProxy.php
@@ -43,6 +43,9 @@ class ItemReferenceProxy extends EntityProxy
             case 'driveType':
                 return $itemReference->getDriveType();
 
+            case 'path':
+                return $itemReference->getPath();
+
             default:
                 return parent::__get($name);
         }

--- a/test/functional/KrizalysOnedriveTest.php
+++ b/test/functional/KrizalysOnedriveTest.php
@@ -172,6 +172,7 @@ EOF;
         $this->assertNull($item->parentReference->id);
         $this->assertNotNull($item->parentReference->driveId);
         $this->assertNotNull($item->parentReference->driveType);
+        $this->assertNotNull($item->parentReference->path);
         $this->assertRootProxy($item->root);
     }
 
@@ -186,6 +187,7 @@ EOF;
         $this->assertNotNull($item->parentReference->id);
         $this->assertNotNull($item->parentReference->driveId);
         $this->assertNotNull($item->parentReference->driveType);
+        $this->assertNotNull($item->parentReference->path);
 
         // For some reason, this special folder does not have a SpecialFolder
         // facet.


### PR DESCRIPTION
parentReference prop always contains `path` addressing the item relative path inside the drive. Although, `driveId` and `driveType` were implemented, they don't also work because they are not implemented in graph api sdk. I sent another [pull request](https://github.com/microsoftgraph/msgraph-sdk-php/pull/114) there as well, to support all these 3 parameters.