### PR TITLE
Added support for state parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change log
 ==========
 
+[Unreleased][unreleased]
+------------------------
+
+### Added
+
+- Support for redirect URI state: see `$state` parameter in
+  `Krizalys\Onedrive\Client::getLogInUrl()`.
+
 [2.4.2] - 2019-09-16
 --------------------
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -261,7 +261,7 @@ class Client
             'response_mode' => 'query',
         ];
         if (false !== $state) {
-            $values['state'] = $state;
+            $values['state'] = (string) $state;
         }
 
         $query = http_build_query($values, '', '&', PHP_QUERY_RFC3986);

--- a/src/Client.php
+++ b/src/Client.php
@@ -239,7 +239,9 @@ class Client
      * @param string $redirectUri
      *        The URI to which to redirect to upon successful log in.
      * @param string $state
-     *        State parameter to be sent with other values.
+     *        The state to pass as a query string value to the redirect URI
+     *        upon successful log in. See {@link
+     *        https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url#use-a-state-parameter "Use a state parameter" in Microsoft Azure documentation for use cases}.
      *
      * @return string
      *         The log in URL.
@@ -248,7 +250,7 @@ class Client
      *
      * @api
      */
-    public function getLogInUrl(array $scopes, $redirectUri, $state = false)
+    public function getLogInUrl(array $scopes, $redirectUri, $state = null)
     {
         $redirectUri                = (string) $redirectUri;
         $this->_state->redirect_uri = $redirectUri;
@@ -260,7 +262,8 @@ class Client
             'scope'         => implode(' ', $scopes),
             'response_mode' => 'query',
         ];
-        if (false !== $state) {
+
+        if ($state !== null) {
             $values['state'] = (string) $state;
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -238,6 +238,8 @@ class Client
      *          - `'files.readwrite.all'`.
      * @param string $redirectUri
      *        The URI to which to redirect to upon successful log in.
+     * @param string $state
+     *        State parameter to be sent with other values.
      *
      * @return string
      *         The log in URL.
@@ -246,7 +248,7 @@ class Client
      *
      * @api
      */
-    public function getLogInUrl(array $scopes, $redirectUri)
+    public function getLogInUrl(array $scopes, $redirectUri, $state = false )
     {
         $redirectUri                = (string) $redirectUri;
         $this->_state->redirect_uri = $redirectUri;
@@ -258,6 +260,9 @@ class Client
             'scope'         => implode(' ', $scopes),
             'response_mode' => 'query',
         ];
+        if ( false !== $state ) {
+            $values['state'] = $state;
+        }
 
         $query = http_build_query($values, '', '&', PHP_QUERY_RFC3986);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -248,7 +248,7 @@ class Client
      *
      * @api
      */
-    public function getLogInUrl(array $scopes, $redirectUri, $state = false )
+    public function getLogInUrl(array $scopes, $redirectUri, $state = false)
     {
         $redirectUri                = (string) $redirectUri;
         $this->_state->redirect_uri = $redirectUri;
@@ -260,7 +260,7 @@ class Client
             'scope'         => implode(' ', $scopes),
             'response_mode' => 'query',
         ];
-        if ( false !== $state ) {
+        if (false !== $state) {
             $values['state'] = $state;
         }
 

--- a/test/functional/ClientTest.php
+++ b/test/functional/ClientTest.php
@@ -3,6 +3,7 @@
 namespace Test\Functional\Krizalys\Onedrive;
 
 use Krizalys\Onedrive\Constant\SpecialFolderName;
+use Krizalys\Onedrive\Onedrive;
 use Krizalys\Onedrive\Proxy\DriveItemProxy;
 use PHPUnit\Framework\TestCase;
 use Test\Functional\Krizalys\Onedrive\Traits\AssertionsTrait;
@@ -17,6 +18,12 @@ class ClientTest extends TestCase
     use ConfigurationTrait;
     use OnedriveSandboxTrait;
 
+    private static $clientId;
+
+    private static $username;
+
+    private static $password;
+
     private static $client;
 
     private static $defaultDrive;
@@ -27,17 +34,32 @@ class ClientTest extends TestCase
     {
         parent::setUpBeforeClass();
 
-        $clientId = self::getConfig('CLIENT_ID');
-        $username = self::getConfig('USERNAME');
-        $password = self::getConfig('PASSWORD');
-        $secret   = self::getConfig('SECRET');
+        self::$clientId = self::getConfig('CLIENT_ID');
+        self::$username = self::getConfig('USERNAME');
+        self::$password = self::getConfig('PASSWORD');
+        $secret         = self::getConfig('SECRET');
 
         self::$client = self::createClient(
-            $clientId,
-            $username,
-            $password,
+            self::$clientId,
+            self::$username,
+            self::$password,
             $secret
         );
+    }
+
+    public function testAuthorizationRequest()
+    {
+        $client = Onedrive::client(self::$clientId);
+
+        $values = self::authorize(
+            $client,
+            self::$username,
+            self::$password,
+            'Test state'
+        );
+
+        $this->assertArrayHasKey('state', $values);
+        $this->assertSame('Test state', $values['state']);
     }
 
     public function testGetDrives()

--- a/test/functional/Traits/ClientFactoryTrait.php
+++ b/test/functional/Traits/ClientFactoryTrait.php
@@ -2,89 +2,24 @@
 
 namespace Test\Functional\Krizalys\Onedrive\Traits;
 
-use Facebook\WebDriver\WebDriver;
 use Krizalys\Onedrive\Onedrive;
-use Symfony\Component\Process\Process;
 
 trait ClientFactoryTrait
 {
-    use MicrosoftOauthAuthorizationTrait;
-    use ProcessTrait;
-    use WebDriverTrait;
-
-    private static $scopes = [
-        'files.read',
-        'files.read.all',
-        'files.readwrite',
-        'files.readwrite.all',
-        'offline_access',
-    ];
-
-    private static $minRedirectPort = 1024;
-
-    private static $maxRedirectPort = 49151;
-
-    private static $redirectUriTemplate = 'http://localhost:%d/';
-
-    private static $webDriverBaseUriTemplate = 'http://localhost:%d/wd/hub';
-
-    private static $webDriverBaseUriPort = 4444;
-
-    private static $uuidRegex = '/M[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/';
+    use OauthAuthorizationTrait;
 
     private static function createClient($clientId, $username, $password, $secret)
     {
         $client = Onedrive::client($clientId);
+        $values = self::authorize($client, $username, $password, null);
 
-        // Random registered port.
-        $redirectUriPort = rand(self::$minRedirectPort, self::$maxRedirectPort);
+        if (!array_key_exists('code', $values)) {
+            throw new \Exception();
+        }
 
-        $redirectUri             = sprintf(self::$redirectUriTemplate, $redirectUriPort);
-        $authorizationRequestUri = $client->getLogInUrl(self::$scopes, $redirectUri);
-        $webDriverBaseUri        = sprintf(self::$webDriverBaseUriTemplate, self::$webDriverBaseUriPort);
-        $root                    = dirname(__DIR__);
-
-        $command = [
-            'php',
-            '-S',
-            sprintf('localhost:%d', $redirectUriPort),
-            sprintf('%s/router.php', $root),
-        ];
-
-        $code = self::withProcess($command, function (Process $process) use ($webDriverBaseUri, $authorizationRequestUri, $redirectUri, $username, $password) {
-            self::withWebDriver($webDriverBaseUri, function (WebDriver $webDriver) use ($authorizationRequestUri, $redirectUri, $username, $password) {
-                self::requestAuthorization($webDriver, $authorizationRequestUri, $redirectUri, $username, $password);
-            });
-
-            foreach ($process as $type => $buffer) {
-                if ($type == Process::OUT) {
-                    $lines = explode("\n", $buffer);
-                    $code  = self::findAuthorizationCode($lines);
-
-                    if ($code !== null) {
-                        break;
-                    }
-                } else {
-                    throw new \Exception($buffer);
-                }
-            }
-
-            return $code;
-        });
-
+        $code = $values['code'];
         $client->obtainAccessToken($secret, $code);
 
         return $client;
-    }
-
-    private static function findAuthorizationCode(array $lines)
-    {
-        foreach ($lines as $line) {
-            $line = trim($line);
-
-            if (preg_match(self::$uuidRegex, $line)) {
-                return $line;
-            }
-        }
     }
 }

--- a/test/functional/Traits/MicrosoftOauthAuthenticationTrait.php
+++ b/test/functional/Traits/MicrosoftOauthAuthenticationTrait.php
@@ -6,7 +6,7 @@ use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 
-trait MicrosoftOauthAuthorizationTrait
+trait MicrosoftOauthAuthenticationTrait
 {
     private static $usernameElementId = 'i0116';
 
@@ -14,7 +14,7 @@ trait MicrosoftOauthAuthorizationTrait
 
     private static $nextElementId = 'idSIButton9';
 
-    private static function requestAuthorization(
+    private static function authenticate(
         WebDriver $webDriver,
         $authorizationRequestUri,
         $redirectUri,

--- a/test/functional/Traits/OauthAuthorizationTrait.php
+++ b/test/functional/Traits/OauthAuthorizationTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Test\Functional\Krizalys\Onedrive\Traits;
+
+use Facebook\WebDriver\WebDriver;
+use Krizalys\Onedrive\Client;
+use Symfony\Component\Process\Process;
+
+trait OauthAuthorizationTrait
+{
+    use MicrosoftOauthAuthenticationTrait;
+    use ProcessTrait;
+    use WebDriverTrait;
+
+    private static $scopes = [
+        'files.read',
+        'files.read.all',
+        'files.readwrite',
+        'files.readwrite.all',
+        'offline_access',
+    ];
+
+    private static $minRedirectPort = 1024;
+
+    private static $maxRedirectPort = 49151;
+
+    private static $redirectUriTemplate = 'http://localhost:%d/';
+
+    private static $webDriverBaseUriTemplate = 'http://localhost:%d/wd/hub';
+
+    private static $webDriverBaseUriPort = 4444;
+
+    private static function authorize(Client $client, $username, $password, $state = null)
+    {
+        // Random registered port.
+        $redirectUriPort = rand(self::$minRedirectPort, self::$maxRedirectPort);
+
+        $redirectUri             = sprintf(self::$redirectUriTemplate, $redirectUriPort);
+        $authorizationRequestUri = $client->getLogInUrl(self::$scopes, $redirectUri, $state);
+        $webDriverBaseUri        = sprintf(self::$webDriverBaseUriTemplate, self::$webDriverBaseUriPort);
+        $root                    = dirname(__DIR__);
+
+        $command = [
+            'php',
+            '-S',
+            sprintf('localhost:%d', $redirectUriPort),
+            sprintf('%s/router.php', $root),
+        ];
+
+        return self::withProcess($command, function (Process $process) use ($webDriverBaseUri, $authorizationRequestUri, $redirectUri, $username, $password) {
+            self::withWebDriver($webDriverBaseUri, function (WebDriver $webDriver) use ($authorizationRequestUri, $redirectUri, $username, $password) {
+                self::authenticate($webDriver, $authorizationRequestUri, $redirectUri, $username, $password);
+            });
+
+            foreach ($process as $type => $buffer) {
+                if ($type == Process::OUT) {
+                    $lines  = explode("\n", $buffer);
+                    $values = self::extractRedirectUriQueryStringValues($lines);
+
+                    if ($values !== null) {
+                        return $values;
+                    }
+                } else {
+                    throw new \Exception("Unsupported process output type: $type");
+                }
+            }
+
+            return null;
+        });
+    }
+
+    private static function extractRedirectUriQueryStringValues(array $lines)
+    {
+        foreach ($lines as $line) {
+            $line = json_decode($line, true);
+
+            if ($line !== null || json_last_error() == JSON_ERROR_NONE) {
+                 return $line;
+            }
+        }
+
+        return null;
+    }
+}

--- a/test/functional/router.php
+++ b/test/functional/router.php
@@ -8,13 +8,13 @@ function route()
 
     if ($path == '/') {
         if (!array_key_exists('query', $components)) {
-            throw new \Exception('code not given');
+            throw new \Exception('Code not given');
         }
 
         parse_str($components['query'], $query);
-        $code   = $query['code'];
+        $query  = json_encode($query);
         $stdout = fopen('php://stdout', 'w');
-        fwrite($stdout, $code);
+        fwrite($stdout, $query);
         fclose($stdout);
     }
 

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -63,8 +63,8 @@ class ClientTest extends TestCase
             'test.scope.2',
         ];
 
-        $actual = $sut->getLogInUrl($scopes, self::REDIRECT_URI);
-        $this->assertEquals('https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=' . self::CLIENT_ID . '&response_type=code&redirect_uri=http%3A%2F%2Fho.st%2Fredirect%2Furi&scope=test.scope.1%20test.scope.2&response_mode=query', $actual);
+        $actual = $sut->getLogInUrl($scopes, self::REDIRECT_URI, 'Test state');
+        $this->assertEquals('https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=' . self::CLIENT_ID . '&response_type=code&redirect_uri=http%3A%2F%2Fho.st%2Fredirect%2Furi&scope=test.scope.1%20test.scope.2&response_mode=query&state=Test%20state', $actual);
     }
 
     public function testGetTokenExpireShouldReturnExpectedValue()


### PR DESCRIPTION
The Redirect URI supports a `state` parameter which is useful for shared Redirect URIs across multiple domains. This adds support as a 3rd function parameter. Documentation here on `state`: https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url