### PR TITLE
Set Access Token in Client Class Constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Change log
 ### Fixed
 
 - All PHP notices.
+- Passing a state via `Krizalys\Onedrive\Client::__construct()`' `'state'`
+  option did not set properly the Microsoft Graph access token.
 
 [2.5.0] - 2019-09-23
 --------------------

--- a/src/Client.php
+++ b/src/Client.php
@@ -196,7 +196,7 @@ class Client
                 'redirect_uri' => null,
                 'token'        => null,
             ];
-        
+
         if (null !== $this->_state->token) {
             $this->graph->setAccessToken($this->_state->token->data->access_token);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -197,7 +197,7 @@ class Client
                 'token'        => null,
             ];
 
-        if (null !== $this->_state->token) {
+        if ($this->_state->token !== null) {
             $this->graph->setAccessToken($this->_state->token->data->access_token);
         }
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -196,6 +196,10 @@ class Client
                 'redirect_uri' => null,
                 'token'        => null,
             ];
+        
+        if (null !== $this->_state->token) {
+            $this->graph->setAccessToken($this->_state->token->data->access_token);
+        }
     }
 
     /**

--- a/test/functional/ClientTest.php
+++ b/test/functional/ClientTest.php
@@ -47,6 +47,40 @@ class ClientTest extends TestCase
         );
     }
 
+    public function testConstructor()
+    {
+        $client = Onedrive::client(self::$clientId);
+
+        $values = self::authorize(
+            $client,
+            self::$username,
+            self::$password,
+            null
+        );
+
+        if (!array_key_exists('code', $values)) {
+            throw new \Exception();
+        }
+
+        $code   = $values['code'];
+        $secret = self::getConfig('SECRET');
+        $client->obtainAccessToken($secret, $code);
+        $state = $client->getState();
+
+        $client = Onedrive::client(
+            self::$clientId,
+            ['state' => $state]
+        );
+
+        $drives = $client->getDrives();
+        $actual = count($drives);
+        $this->assertGreaterThanOrEqual(1, $actual);
+
+        foreach ($drives as $drive) {
+            $this->assertDriveProxy($drive);
+        }
+    }
+
     public function testAuthorizationRequest()
     {
         $client = Onedrive::client(self::$clientId);

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -79,7 +79,11 @@ class ClientTest extends TestCase
                 'state' => (object) [
                     'token' => (object) [
                         'obtained' => strtotime('1999-01-01Z'),
-                        'data'     => (object) ['expires_in' => 3600],
+
+                        'data' => (object) [
+                            'access_token' => 'AcCeSs+ToKeN',
+                            'expires_in'   => 3600,
+                        ],
                     ],
                 ],
             ],
@@ -127,7 +131,11 @@ class ClientTest extends TestCase
                 'state' => (object) [
                     'token' => (object) [
                         'obtained' => strtotime('1999-01-01Z'),
-                        'data'     => (object) ['expires_in' => 3600],
+
+                        'data' => (object) [
+                            'access_token' => 'AcCeSs+ToKeN',
+                            'expires_in'   => 3600,
+                        ],
                     ],
                 ],
             ],
@@ -171,6 +179,7 @@ class ClientTest extends TestCase
 
                     'token' => (object) [
                         'obtained' => strtotime('1999-01-01Z'),
+                        'data'     => (object) ['access_token'  => 'AcCeSs+ToKeN'],
                     ],
                 ],
             ],
@@ -240,7 +249,11 @@ class ClientTest extends TestCase
                 'state' => (object) [
                     'token' => (object) [
                         'obtained' => strtotime('1999-01-01Z'),
-                        'data'     => (object) ['refresh_token' => 'ReFrEsH+ToKeN'],
+
+                        'data' => (object) [
+                            'access_token'  => 'AcCeSs+ToKeN',
+                            'refresh_token' => 'ReFrEsH+ToKeN',
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
The README explains to use the following code to restore a session:

```
$client = Onedrive::client(
    $config['ONEDRIVE_CLIENT_ID'],
    [
        // Restore the previous state while instantiating this client to proceed
        // in obtaining an access token.
        'state' => $_SESSION['onedrive.client.state'],
    ]
);
```
However the `state` and `token` are never set in `$this->graph` causing any API requests to fail. This code restores the session properly if the token parameter is not `null`. Useful when passing `state` into the `$options` array.