### PR TITLE
Replace stream_for() with Utils::\streamFor()

### DIFF
--- a/src/Proxy/DriveItemProxy.php
+++ b/src/Proxy/DriveItemProxy.php
@@ -553,7 +553,7 @@ class DriveItemProxy extends BaseItemProxy
 
         $body = $content instanceof Stream ?
             $content
-            : Psr7\stream_for($content);
+            : Psr7\Utils::streamFor($content);
 
         try {
             $response = $this


### PR DESCRIPTION
This is related to https://github.com/guzzle/guzzle/pull/2712.

* [ ] I have described my changes in the
  [CHANGELOG](https://github.com/krizalys/onedrive-php-sdk/blob/master/CHANGELOG.md)
* [ ] I have adopted the
  [coding style](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/CodingStyle.md)
* [ ] I have followed the [contributor
  rules](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/ContributorRules.md)
* [ ] I have added consistent [PHPDoc](https://www.phpdoc.org/) documentation to
  symbols I added
* [ ] I have fixed an issue and I added [unit test
  case(s)](https://github.com/krizalys/onedrive-php-sdk/tree/master/test/unit)
* [ ] I have added a feature and I added [functional test
  case(s)](https://github.com/krizalys/onedrive-php-sdk/tree/master/test/functional)
* [ ] I have passed all continuous integration checks or discussed with project
  maintainers of special treatments for exceptional cases
* [x] I accept my contribution to be code-reviewed by project maintainers and
  will refine it as requested
* [x] I accept my pull request to be rejected at the project maintainers'
  discretion, **even if it complies with all the above guidelines**