### PR TITLE
fixed the incorrect variable name $queryStringParameterDefinition in …

### DIFF
--- a/src/Definition/OperationDefinition.php
+++ b/src/Definition/OperationDefinition.php
@@ -47,7 +47,7 @@ class OperationDefinition implements OperationDefinitionInterface
      *
      * @since 2.5.0
      */
-    private $queryStringParameterDefinition;
+    private $queryStringParameterDefinitions;
 
     /**
      * Constructor.


### PR DESCRIPTION
…class \Krizalys\Onedrive\Definition\OperationDefinition

A typo in the name of the class variable has been corrected. Without this fix, your library does not work on PHP 8.2 and above
