### PR TITLE
Calling a private variable "redirectUri" is replaced by getting the v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change log
 ==========
 
+[3.2.1] - 2023-08-20
+--------------------
+
+### Fixed
+
+- Calling a private variable "redirectUri" is replaced by getting the value of this one using the __get() method
+
 [3.2.0] - 2023-03-31
 --------------------
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client
      */
     public function obtainAccessToken($clientSecret, $code)
     {
-        if ($this->state->redirectUri === null) {
+        if ($this->state->__get("redirectUri") === null) {
             throw new \Exception(
                 'The state\'s redirect URI must be set to call'
                     . ' obtainAccessToken()'

--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client
      */
     public function obtainAccessToken($clientSecret, $code)
     {
-        if ($this->state->__get("redirectUri") === null) {
+        if ($this->state->__get('redirectUri') === null) {
             throw new \Exception(
                 'The state\'s redirect URI must be set to call'
                     . ' obtainAccessToken()'


### PR DESCRIPTION
…alue of this one using the __get() method

Thanks for your pull request!

Before we consider merging it, please take the time to ensure you are complying with these guidelines:

* [x] I have described my changes in the [CHANGELOG](https://github.com/krizalys/onedrive-php-sdk/blob/master/CHANGELOG.md)
* [x] I have adopted the [coding style](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/CodingStyle.md)
* [x] I have followed the [contributor rules](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/ContributorRules.md)
* [x] I have added consistent [PHPDoc](https://www.phpdoc.org/) documentation to symbols I added
* [x] I have fixed an issue and I added [unit test case(s)](https://github.com/krizalys/onedrive-php-sdk/tree/master/test/unit)
* [x] I have added a feature and I added [functional test case(s)](https://github.com/krizalys/onedrive-php-sdk/tree/master/test/functional)
* [x] I have passed all continuous integration checks or discussed with project maintainers of special treatments for exceptional cases
* [x] I accept my contribution to be code-reviewed by project maintainers and will refine it as requested
* [x] I accept my pull request to be rejected at the project maintainers' discretion, **even if it complies with all the above guidelines**

**Failure to comply with the above guidelines will lead to your pull request being either modified for compliance, ignored until modified for compliance, and/or rejected altogether.**
