### PR TITLE
Calling a private variable "redirectUri" is replaced by getting the value of this one using the __get() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change log
 ==========
 
+[3.2.1] - 2023-08-20
+--------------------
+
+### Fixed
+
+- Calling a private variable "redirectUri" is replaced by getting the value of this one using the __get() method
+
 [3.2.0] - 2023-03-31
 --------------------
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client
      */
     public function obtainAccessToken($clientSecret, $code)
     {
-        if ($this->state->redirectUri === null) {
+        if ($this->state->__get("redirectUri") === null) {
             throw new \Exception(
                 'The state\'s redirect URI must be set to call'
                     . ' obtainAccessToken()'

--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client
      */
     public function obtainAccessToken($clientSecret, $code)
     {
-        if ($this->state->__get("redirectUri") === null) {
+        if ($this->state->__get('redirectUri') === null) {
             throw new \Exception(
                 'The state\'s redirect URI must be set to call'
                     . ' obtainAccessToken()'


### PR DESCRIPTION
Thanks for your pull request!

Before we consider merging it, please take the time to ensure you are complying with these guidelines:

* [x] I have described my changes in the [CHANGELOG](https://github.com/krizalys/onedrive-php-sdk/blob/master/CHANGELOG.md)
* [x] I have adopted the [coding style](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/CodingStyle.md)
* [x] I have followed the [contributor rules](https://github.com/krizalys/onedrive-php-sdk/tree/master/doc/ContributorRules.md)
